### PR TITLE
Use RUBY_TEST_TIMEOUT_SCALE for tests

### DIFF
--- a/test/mmtk/helper.rb
+++ b/test/mmtk/helper.rb
@@ -9,7 +9,16 @@ module MMTk
 
     def setup
       omit "Not running on MMTk" unless using_mmtk?
+
+      @original_timeout_scale = EnvUtil.timeout_scale
+      timeout_scale = ENV["RUBY_TEST_TIMEOUT_SCALE"].to_f
+      EnvUtil.timeout_scale = timeout_scale if timeout_scale > 0
+
       super
+    end
+
+    def teardown
+      EnvUtil.timeout_scale = @original_timeout_scale
     end
 
     private

--- a/test/mmtk/test_configuration.rb
+++ b/test/mmtk/test_configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
+
 require_relative "helper"
+
 module MMTk
   class TestConfiguration < TestCase
     def test_MMTK_THREADS


### PR DESCRIPTION
RUBY_TEST_TIMEOUT_SCALE is set for debug builds because they are slower to run. We should respect this environment variable in MMTk tests too.