### PR TITLE
Trigger forced GC in GC.start

### DIFF
--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -562,16 +562,7 @@ rb_gc_impl_shutdown_free_objects(void *objspace_ptr)
 void
 rb_gc_impl_start(void *objspace_ptr, bool full_mark, bool immediate_mark, bool immediate_sweep, bool compact)
 {
-    bool enabled = mmtk_gc_enabled_p();
-    if (!enabled) {
-        mmtk_set_gc_enabled(true);
-    }
-
-    mmtk_handle_user_collection_request(rb_gc_get_ractor_newobj_cache());
-
-    if (!enabled) {
-        mmtk_set_gc_enabled(false);
-    }
+    mmtk_handle_user_collection_request(rb_gc_get_ractor_newobj_cache(), true, full_mark);
 }
 
 bool
@@ -667,7 +658,7 @@ rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags
     }
 
     if (objspace->gc_stress) {
-        mmtk_handle_user_collection_request(ractor_cache);
+        mmtk_handle_user_collection_request(ractor_cache, false, false);
     }
 
     VALUE *alloc_obj = mmtk_alloc(ractor_cache->mutator, alloc_size + 8, MMTk_MIN_OBJ_ALIGN, 0, MMTK_ALLOCATION_SEMANTICS_DEFAULT);

--- a/gc/mmtk/mmtk.h
+++ b/gc/mmtk/mmtk.h
@@ -96,7 +96,7 @@ MMTk_Mutator *mmtk_bind_mutator(MMTk_VMMutatorThread tls);
 
 void mmtk_destroy_mutator(MMTk_Mutator *mutator);
 
-void mmtk_handle_user_collection_request(MMTk_VMMutatorThread tls);
+void mmtk_handle_user_collection_request(MMTk_VMMutatorThread tls, bool force, bool exhaustive);
 
 void mmtk_set_gc_enabled(bool enable);
 

--- a/gc/mmtk/src/api.rs
+++ b/gc/mmtk/src/api.rs
@@ -174,8 +174,12 @@ pub extern "C" fn mmtk_destroy_mutator(mutator: *mut RubyMutator) {
 // =============== GC ===============
 
 #[no_mangle]
-pub extern "C" fn mmtk_handle_user_collection_request(tls: VMMutatorThread) {
-    memory_manager::handle_user_collection_request::<Ruby>(mmtk(), tls);
+pub extern "C" fn mmtk_handle_user_collection_request(
+    tls: VMMutatorThread,
+    force: bool,
+    exhaustive: bool,
+) {
+    crate::mmtk().handle_user_collection_request(tls, force, exhaustive);
 }
 
 #[no_mangle]


### PR DESCRIPTION
We now use `MMTK::handle_user_collection_request(true, ...)` to force triggering a GC instead of enabling GC temporarily.