### PR TITLE
Do root scanning in scan_vm_specific_roots

### DIFF
--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -203,7 +203,13 @@ rb_mmtk_get_mutators(void (*visit_mutator)(MMTk_Mutator *mutator, void *data), v
 static void
 rb_mmtk_scan_gc_roots(void)
 {
-    // rb_gc_mark_roots(rb_gc_get_objspace(), NULL);
+    struct objspace *objspace = rb_gc_get_objspace();
+
+    // FIXME: Make `rb_gc_mark_roots` aware that the current thread may not have EC.
+    // See: https://github.com/ruby/mmtk/issues/22
+    rb_gc_worker_thread_set_vm_context(&objspace->vm_context);
+    rb_gc_mark_roots(objspace, NULL);
+    rb_gc_worker_thread_unset_vm_context(&objspace->vm_context);
 }
 
 static int
@@ -239,18 +245,6 @@ rb_mmtk_scan_objspace(void)
         }
 
         job = job->next;
-    }
-}
-
-static void
-rb_mmtk_scan_roots_in_mutator_thread(MMTk_VMMutatorThread mutator, MMTk_VMWorkerThread worker)
-{
-    if (mutator->gc_mutator_p) {
-        struct objspace *objspace = rb_gc_get_objspace();
-
-        rb_gc_worker_thread_set_vm_context(&objspace->vm_context);
-        rb_gc_mark_roots(objspace, NULL);
-        rb_gc_worker_thread_unset_vm_context(&objspace->vm_context);
     }
 }
 
@@ -402,7 +396,6 @@ MMTk_RubyUpcalls ruby_upcalls = {
     rb_mmtk_get_mutators,
     rb_mmtk_scan_gc_roots,
     rb_mmtk_scan_objspace,
-    rb_mmtk_scan_roots_in_mutator_thread,
     rb_mmtk_scan_object_ruby_style,
     rb_mmtk_call_gc_mark_children,
     rb_mmtk_call_obj_free,

--- a/gc/mmtk/mmtk.h
+++ b/gc/mmtk/mmtk.h
@@ -61,8 +61,6 @@ typedef struct MMTk_RubyUpcalls {
     void (*get_mutators)(void (*visit_mutator)(MMTk_Mutator*, void*), void *data);
     void (*scan_gc_roots)(void);
     void (*scan_objspace)(void);
-    void (*scan_roots_in_mutator_thread)(MMTk_VMMutatorThread mutator_tls,
-                                         MMTk_VMWorkerThread worker_tls);
     void (*scan_object_ruby_style)(MMTk_ObjectReference object);
     void (*call_gc_mark_children)(MMTk_ObjectReference object);
     void (*call_obj_free)(MMTk_ObjectReference object);

--- a/gc/mmtk/src/abi.rs
+++ b/gc/mmtk/src/abi.rs
@@ -315,8 +315,6 @@ pub struct RubyUpcalls {
     ),
     pub scan_gc_roots: extern "C" fn(),
     pub scan_objspace: extern "C" fn(),
-    pub scan_roots_in_mutator_thread:
-        extern "C" fn(mutator_tls: VMMutatorThread, worker_tls: VMWorkerThread),
     pub scan_object_ruby_style: extern "C" fn(object: ObjectReference),
     pub call_gc_mark_children: extern "C" fn(object: ObjectReference),
     pub call_obj_free: extern "C" fn(object: ObjectReference),


### PR DESCRIPTION
We rely on scan_vm_specific_roots to reach all stacks via the following path:

    VM -> ractors -> threads -> fibers -> stacks