### PR TITLE
Forward port GH-13031 from ruby/ruby

### DIFF
--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -191,9 +191,7 @@ static void
 rb_mmtk_get_mutators(void (*visit_mutator)(MMTk_Mutator *mutator, void *data), void *data)
 {
     struct objspace *objspace = rb_gc_get_objspace();
-
     struct MMTk_ractor_cache *ractor_cache;
-    RUBY_ASSERT(ractor_cache != NULL);
 
     ccan_list_for_each(&objspace->ractor_caches, ractor_cache, list_node) {
         visit_mutator(ractor_cache->mutator, data);


### PR DESCRIPTION
Pick commit from https://github.com/ruby/ruby/pull/13031

```
Remove incorrect assertion
ractor_cache will always be NULL in this context
```