### PR TITLE
Add obj_need_obj_free_p

### DIFF
--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -906,6 +906,20 @@ obj_can_parallel_free_p(VALUE obj)
     }
 }
 
+static bool
+obj_need_obj_free_p(VALUE obj)
+{
+    switch (RB_BUILTIN_TYPE(obj)) {
+      case T_FLOAT:
+      case T_RATIONAL:
+      case T_COMPLEX:
+      case T_OBJECT:
+        return false;
+      default:
+        return true;
+    }
+}
+
 static void
 mmtk_flush_obj_free_buffer(struct MMTk_ractor_cache *cache)
 {
@@ -1001,8 +1015,9 @@ rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags
         mmtk_post_alloc_fast_immix(objspace, ractor_cache, (uintptr_t)alloc_obj);
     }
 
-    // TODO: only add when object needs obj_free to be called
-    mmtk_buffer_obj_free_candidate(ractor_cache, (VALUE)alloc_obj);
+    if (obj_need_obj_free_p((VALUE)alloc_obj)) {
+        mmtk_buffer_obj_free_candidate(ractor_cache, (VALUE)alloc_obj);
+    }
 
     objspace->total_allocated_objects++;
 


### PR DESCRIPTION
We don't need to call obj_free on certain types of objects anymore including T_FLOAT, T_RATIONAL, T_COMPLEX, and T_OBJECT. It makes freeing those objects faster.

Benchmark:

```ruby
i = 0
while i < 10_000_000
  Object.new
  i += 1
end
```

Before:

    Time (mean ± σ):      1.435 s ±  0.013 s    [User: 1.706 s, System: 1.970 s]
    Range (min … max):    1.418 s …  1.461 s    10 runs

After:

    Time (mean ± σ):      1.230 s ±  0.027 s    [User: 1.335 s, System: 1.743 s]
    Range (min … max):    1.206 s …  1.294 s    10 runs