### PR TITLE
Prevent overflow values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 Gemfile.lock
 
 tmp
+
+.DS_Store

--- a/gc/mmtk/src/utils.rs
+++ b/gc/mmtk/src/utils.rs
@@ -156,8 +156,8 @@ mod tests {
         assert_eq!(None, parse_capacity("99999999999999MiB"));
         assert_eq!(None, parse_capacity("99999999999999999KiB"));
 
-        const GIBIBYTE: usize = 1024 * 1024 * 1024;           
-        let max_gib = usize::MAX / GIBIBYTE; 
+        const GIBIBYTE: usize = 1024 * 1024 * 1024;
+        let max_gib = usize::MAX / GIBIBYTE;
         assert_eq!(
             Some(max_gib * GIBIBYTE),
             parse_capacity(&format!("{max_gib}GiB"))

--- a/gc/mmtk/src/utils.rs
+++ b/gc/mmtk/src/utils.rs
@@ -118,9 +118,9 @@ pub fn parse_capacity(input: &str) -> Option<usize> {
     };
 
     match suffix {
-        "GiB" => Some(v * GIBIBYTE),
-        "MiB" => Some(v * MEBIBYTE),
-        "KiB" => Some(v * KIBIBYTE),
+        "GiB" => v.checked_mul(GIBIBYTE),
+        "MiB" => v.checked_mul(MEBIBYTE),
+        "KiB" => v.checked_mul(KIBIBYTE),
         "" => Some(v),
         _ => None,
     }
@@ -148,6 +148,20 @@ mod tests {
     #[test]
     fn test_parse_capacity_parses_gibibytes() {
         assert_eq!(Some(10737418240), parse_capacity("10GiB"))
+    }
+
+    #[test]
+    fn test_parse_capacity_rejects_overflowing_values() {
+        assert_eq!(None, parse_capacity("99999999999GiB"));
+        assert_eq!(None, parse_capacity("99999999999999MiB"));
+        assert_eq!(None, parse_capacity("99999999999999999KiB"));
+
+        const GIBIBYTE: usize = 1024 * 1024 * 1024;           
+        let max_gib = usize::MAX / GIBIBYTE; 
+        assert_eq!(
+            Some(max_gib * GIBIBYTE),
+            parse_capacity(&format!("{max_gib}GiB"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Changed `parse_capacity` to use `checked_mul` so that oversized values return None. This should help since `parse_capacity` feeds `MMTK_HEAP_MAX` and returning None routes into the existing "[FATAL] Invalid {key} {val}" + exit(1) path. So the user visible change is that an oversized value now gets a clear fatal error instead of silently wrapping to a garbage heap max.


To reproduce

- From the repo root, script builds cdylib and probes the real `mmtk_builder_default()` entry point.

```bash
#!/bin/sh
set -e

( cd gc/mmtk && cargo build --release )

LIB=gc/mmtk/target/release/libmmtk_ruby.so
[ -f "$LIB" ] || LIB=gc/mmtk/target/release/libmmtk_ruby.dylib

TMP=$(mktemp -d)
trap 'rm -rf "$TMP"' EXIT

# Calls the real mmtk_builder_default() -- the same entry point mmtk.c calls at
# boot. so this exercises the mmtk_builder_default_parse_heap_max -> parse_env_var_with -> parse_capacity
cat > "$TMP/driver.c" <<'EOF'
#include <stdio.h>
#include <dlfcn.h>
int main(int argc, char **argv) {
    void *h = dlopen(argv[1], RTLD_NOW);
    if (!h) { fprintf(stderr, "dlopen failed: %s\n", dlerror()); return 2; }
    void *(*builder)(void) = dlsym(h, "mmtk_builder_default");
    if (!builder) { fprintf(stderr, "dlsym failed: %s\n", dlerror()); return 2; }
    void *b = builder();
    printf("  -> builder created at %p; boot continued, no error reported\n", b);
    return 0;
}
EOF

[ "$(uname)" = "Linux" ] && DL=-ldl || DL=
cc -O0 -o "$TMP/driver" "$TMP/driver.c" $DL

for val in 4GiB 99999999999GiB 17179869184GiB; do
    echo ""
    echo "--- MMTK_HEAP_MAX=$val"
    MMTK_HEAP_MAX=$val "$TMP/driver" "$LIB" || echo "  exit code: $?"
done
echo ""
```

Basically for this branch outputs
```
--- MMTK_HEAP_MAX=4GiB
-> builder created at 0x104f15890; boot continued, no error reported

--- MMTK_HEAP_MAX=99999999999GiB
[FATAL] Invalid MMTK_HEAP_MAX 99999999999GiB
exit code: 1

--- MMTK_HEAP_MAX=17179869184GiB
[FATAL] Invalid MMTK_HEAP_MAX 17179869184GiB
exit code: 1
 ```

Current main branch at time of posting PR
```
--- MMTK_HEAP_MAX=4GiB
-> builder created at 0x102c75c00; boot continued, no error reported

--- MMTK_HEAP_MAX=99999999999GiB
-> builder created at 0x1038ddc00; boot continued, no error reported

--- MMTK_HEAP_MAX=17179869184GiB
[FATAL] MMTK_HEAP_MIN(1048576) >= MMTK_HEAP_MAX(0)
exit code: 1
```

for the second one 99999999999GiB wraps to ~15140462030378500096 bytes and boots with a heap different then requested.

for the third one  17179869184GiB wrapped to zero. This triggered the error MMTK_HEAP_MIN(1048576) >= MMTK_HEAP_MAX(0).

